### PR TITLE
Fixed the issue of overflowing hero image

### DIFF
--- a/src/Components/Hero/Hero.css
+++ b/src/Components/Hero/Hero.css
@@ -57,3 +57,7 @@
     align-items: center;
     justify-content: center;
 }
+.hero-right img{
+    height: 650px;
+
+}


### PR DESCRIPTION
Fixes #8 

I have fixed the overflowing issue of the hero image.

Screenshot:
![Screenshot (82)](https://github.com/JiyaGupta-cs/ShopNex/assets/127030695/2ae34372-3865-4b1c-9633-eaf7fe36fbb1)

Contributing under JWOC.