### PR TITLE
Fix dark mode behavior to persist after page refresh

### DIFF
--- a/src/Components/Navbar/Navbar.jsx
+++ b/src/Components/Navbar/Navbar.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext, useState, useEffect } from 'react';
 import './Navbar.css';
 import logo from '../Assets/logo.png';
 import cart_icon from '../Assets/cart_icon.png';
@@ -9,21 +9,25 @@ import { Link } from 'react-router-dom';
 import { ShopContext } from '../../Context/ShopContext';
 
 const Navbar = () => {
-    const [icon, setIcon] = useState(cart_icon);
-    const [menu, setMenu] = useState("shop");
     const { getTotalCartItems, theme, setTheme } = useContext(ShopContext);
+    const [icon, setIcon] = useState(theme === "dark" ? cart_icon_dark : cart_icon);
+    const [menu, setMenu] = useState("shop");
+
+    useEffect(() => {
+        if (theme === "dark") {
+            document.getElementById("nav").classList.add("dark");
+            setIcon(cart_icon_dark);
+        } else {
+            document.getElementById("nav").classList.remove("dark");
+            setIcon(cart_icon);
+        }
+    }, [theme]);
 
     const toggle = () => {
         if (theme === "dark") {
             setTheme("light");
-            setIcon(cart_icon_dark);
-            const dnav = document.getElementById("nav");
-            dnav.classList.add("dark");
         } else {
             setTheme("dark");
-            setIcon(cart_icon);
-            const dnav = document.getElementById("nav");
-            dnav.classList.remove("dark");
         }
     };
 
@@ -64,7 +68,7 @@ const Navbar = () => {
                 </div>
             </div>
         </div>
-    )
-}
+    );
+};
 
 export default Navbar;

--- a/src/Context/ShopContext.jsx
+++ b/src/Context/ShopContext.jsx
@@ -1,20 +1,26 @@
 import React, { createContext, useState } from "react";
 import all_product from "../Components/Assets/all_product";
+import { useEffect } from "react";
 
 export const ShopContext = createContext(null);
 
 const ShopContextProvider = (props) => {
   const [cartItems, setcartItems] = useState([]);
-  const [theme,setTheme]=useState("dark");
+  const [theme, setTheme] = useState(localStorage.getItem("theme") || "light");
+  useEffect(() => {
+    localStorage.setItem("theme", theme);
+  }, [theme]);
   const addToCart = (itemId, size, quantity) => {
-    const existingCartItemIndex = cartItems.findIndex(item => item.id === itemId && item.size === size);
-  
+    const existingCartItemIndex = cartItems.findIndex(
+      (item) => item.id === itemId && item.size === size
+    );
+
     if (existingCartItemIndex !== -1) {
       const updatedCartItems = cartItems.map((item, index) => {
         if (index === existingCartItemIndex) {
           return {
             ...item,
-            quantity: item.quantity + quantity
+            quantity: item.quantity + quantity,
           };
         }
         return item;
@@ -27,16 +33,17 @@ const ShopContextProvider = (props) => {
       setcartItems([...cartItems, cartProduct]);
     }
   };
-  
+
   const removeFromCart = (itemId) => {
     setcartItems(cartItems.filter((product) => product.id !== itemId));
   };
 
   const getTotalCartAmount = () => {
-    return cartItems.reduce((total, product) => total + (product.new_price * product.quantity), 0);
+    return cartItems.reduce(
+      (total, product) => total + product.new_price * product.quantity,
+      0
+    );
   };
-  
-  
 
   const getTotalCartItems = () => {
     return cartItems.length;


### PR DESCRIPTION
# Fix dark mode behavior to persist after page refresh
Title :Fix dark mode behavior to persist after page refresh

Close #<304>
<!-- Example Close #304  -->
<!-- Replace `issue_no` with the issue number which is fixed in this PR -->

Steps Taken:
Local Storage Integration: Implemented code to save the theme preference (light or dark) in local storage whenever the user toggles the theme.
Theme Initialization: Updated the application to check local storage for the saved theme preference during initialization and apply it accordingly.
Context Update: Modified the ShopContext to handle reading from and writing to local storage for the theme setting.
Benefits:
Consistent User Experience: Users no longer need to manually switch back to their preferred theme after refreshing the page.
Improved Usability: Enhances the overall usability of the website by remembering user preferences.

## Screenshots (if applicable)
[

Uploading shopNex fix.mp4…

]

## Checklist
- [x] I have tested these changes locally.
- [x] I have reviewed the code and ensured it follows the project's coding standards.
- [x] I have updated the documentation (if necessary).
- [x] I have read the contributing guidelines.



