### PR TITLE
Fix: Dark mode toggles off on page refresh

### DIFF
--- a/src/Context/ShopContext.jsx
+++ b/src/Context/ShopContext.jsx
@@ -1,11 +1,20 @@
-import React, { createContext, useState } from "react";
+import React, { createContext, useEffect, useState } from "react";
 import all_product from "../Components/Assets/all_product";
 
 export const ShopContext = createContext(null);
 
 const ShopContextProvider = (props) => {
   const [cartItems, setcartItems] = useState([]);
-  const [theme,setTheme]=useState("dark");
+  const [theme, setTheme] = useState(() => {
+    return localStorage.getItem('theme') || 'light';
+  });
+  
+  useEffect(() => {
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+  
+
+  
   const addToCart = (itemId, size, quantity) => {
     const existingCartItemIndex = cartItems.findIndex(item => item.id === itemId && item.size === size);
   


### PR DESCRIPTION
# Title and Issue number 
Title : Dark mode gets turned off on refreshing page | Fixed
Description: This PR fixes the issue where the dark mode setting gets turned off when the page is refreshed. The theme preference is now properly saved and loaded from `localStorage`.
Issue No. : #472

Close #472

## Changes Made
The changes i made to this part of the code ensure that the theme is correctly initialized from `localStorage` and that any changes to the theme are persisted back to `localStorage`. This allows the application to remember the user's theme preference even after the page is refreshed.
# Original Code:
```
const [theme, setTheme] = useState("dark");
```
# Updated Code:
```
const [theme, setTheme] = useState(() => {
    return localStorage.getItem('theme') || 'light';
});

useEffect(() => {
    localStorage.setItem('theme', theme);
}, [theme]);

```

## Screenshots
# before

https://github.com/JiyaGupta-cs/ShopNex/assets/105265591/58f2d4db-95a0-48ab-ac1a-86f6fda08f37



# After

https://github.com/JiyaGupta-cs/ShopNex/assets/105265591/cf517247-e721-4241-8c53-f8e4ecc86822


## Checklist
- [x] I have tested these changes locally.
- [x] I have reviewed the code and ensured it follows the project's coding standards.
- [x] I have read the contributing guidelines.

I'm contributing this under GirlScript summer of code.
Please review my PR and let me know if any changes are required.



