### PR TITLE
Resolved light mode persist issue

### DIFF
--- a/src/Components/Navbar/Navbar.jsx
+++ b/src/Components/Navbar/Navbar.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext, useState, useEffect } from 'react';
 import './Navbar.css';
 import logo from '../Assets/logo.png';
 import cart_icon from '../Assets/cart_icon.png';
@@ -13,19 +13,41 @@ const Navbar = () => {
     const [menu, setMenu] = useState("shop");
     const { getTotalCartItems, theme, setTheme } = useContext(ShopContext);
 
-    const toggle = () => {
+    // Function to toggle theme
+    const toggleTheme = () => {
         if (theme === "dark") {
             setTheme("light");
             setIcon(cart_icon_dark);
-            const dnav = document.getElementById("nav");
-            dnav.classList.add("dark");
+            localStorage.setItem('theme', 'light'); // Store theme preference in localStorage
         } else {
             setTheme("dark");
             setIcon(cart_icon);
-            const dnav = document.getElementById("nav");
-            dnav.classList.remove("dark");
+            localStorage.setItem('theme', 'dark'); // Store theme preference in localStorage
         }
     };
+
+    // Effect to set theme when component mounts
+    useEffect(() => {
+        const storedTheme = localStorage.getItem('theme');
+        if (storedTheme) {
+            setTheme(storedTheme);
+            if (storedTheme === 'dark') {
+                setIcon(cart_icon_dark);
+            } else {
+                setIcon(cart_icon);
+            }
+        }
+    }, []); // Empty dependency array ensures this effect runs only once on mount
+
+    // Update theme-related classes dynamically
+    useEffect(() => {
+        const nav = document.getElementById("nav");
+        if (theme === 'dark') {
+            nav.classList.add('dark');
+        } else {
+            nav.classList.remove('dark');
+        }
+    }, [theme]); // Run this effect whenever theme changes
 
     return (
         <div className={`navbar`} id="nav">
@@ -58,8 +80,8 @@ const Navbar = () => {
                 <Link to='/cart'><img src={icon} alt="" className='cart' /></Link>
                 <div className="nav-cart-count">{getTotalCartItems()}</div>
                 <div className='dark_btn'>
-                    <button onClick={toggle} className={`toggle_${theme} change`}>
-                        {theme === 'light' ? <img src={sunIcon}  /> : <img src={moonIcon}  />}
+                    <button onClick={toggleTheme} className={`toggle_${theme} change`}>
+                        {theme === 'light' ? <img src={sunIcon} alt="Light Mode" /> : <img src={moonIcon} alt="Dark Mode" />}
                     </button>
                 </div>
             </div>


### PR DESCRIPTION

Hey @JiyaGupta-cs  ,
issue closes #503 
I have resolved the issue to persist the light mode preference across page refreshes using localStorage.
The changes ensure that the user's selected mode (dark or light) is maintained even after the page is refreshed.

**Changes made are as follows :**

Added functionality to check "localStorage" for the user's light mode preference upon page load and set the initial state accordingly.
Updated the event listener for the toggle switch to save the light mode preference in localStorage whenever the user changes the mode.
Now, Whenever user will refresh or log in the page again, The selected mode preference will be the same as chosen.

******Screenshot/Video:******


https://github.com/JiyaGupta-cs/ShopNex/assets/160386036/b06e2f60-2e97-4ab5-aba0-81d6bf26e0a9



Please take a look and review it.
Also, please add the labels.
