### PR TITLE
Fix: Ensure kids section photos are visible

### DIFF
--- a/src/Pages/ShopCategory.jsx
+++ b/src/Pages/ShopCategory.jsx
@@ -12,8 +12,8 @@ const ShopCategory = (props) => {
 
   let filteredProducts;
 
-  if (props.category === 'kids') {
-    filteredProducts = all_product.filter(item => item.category === 'kids');
+  if (props.category === 'kids' || props.category === 'kid') {
+    filteredProducts = all_product.filter(item => item.category === 'kid');
   } else {
     filteredProducts = all_product.filter(item => item.category === props.category);
     while (filteredProducts.length < 76) {


### PR DESCRIPTION
# Title and Issue Number
**Title:** Kids section not visible  
**Issue No.:** #558

Closes #558

Since there was no recent progress on issue #558, I took the initiative to implement a fix. Please feel free to review and provide feedback.

## Changes Made
1. Updated the condition from `props.category === 'kids'` to `props.category === 'kid'`.

## Screenshots (if applicable)
**Before the Change:** The kids section was not visible.  
![Before Change](https://github.com/user-attachments/assets/7ab0ea14-9198-4e25-9cff-1c55bfb646b0)

**After the Change:**  
![After Change](https://github.com/user-attachments/assets/de2f24fd-6295-408a-9db3-7dd11ed4457b)  
![After Change 2](https://github.com/user-attachments/assets/38770bdb-f4bd-4037-8edf-5434ef32ebfd)

## Checklist
- [x] I have tested these changes locally.
- [x] I have reviewed the code and ensured it follows the project's coding standards.
- [ ] I have updated the documentation (if necessary).
- [x] I have read the contributing guidelines.
