### PR TITLE
fix: Persist dark mode setting across page reloads

### DIFF
--- a/src/Context/ShopContext.jsx
+++ b/src/Context/ShopContext.jsx
@@ -1,11 +1,15 @@
-import React, { createContext, useState } from "react";
+import React, { createContext, useState, useEffect } from "react";
 import all_product from "../Components/Assets/all_product";
 
 export const ShopContext = createContext(null);
 
 const ShopContextProvider = (props) => {
   const [cartItems, setcartItems] = useState([]);
-  const [theme,setTheme]=useState("dark");
+  const [theme, setTheme] = useState(() => {
+    // Initialize theme from localStorage or default to "dark"
+    const savedTheme = localStorage.getItem('shopnex-theme');
+    return savedTheme || "dark";
+  });
   const addToCart = (itemId, size, quantity) => {
     const existingCartItemIndex = cartItems.findIndex(item => item.id === itemId && item.size === size);
   
@@ -41,6 +45,11 @@ const ShopContextProvider = (props) => {
   const getTotalCartItems = () => {
     return cartItems.length;
   };
+
+  // useEffect hook for localStorage persistence of theme
+  useEffect(() => {
+    localStorage.setItem('shopnex-theme', theme);
+  }, [theme]);
 
   const contextValue = {
     all_product,


### PR DESCRIPTION
🐛 Bug Fix:
- Dark mode setting now persists in localStorage
- Theme preference is maintained across browser sessions
- Initialize theme from localStorage on app load

🔧 Technical Changes:
- Added useEffect hook for localStorage persistence
- Enhanced theme state initialization with localStorage check
- Automatic saving when theme state changes

✅ Resolves:
- Dark mode resetting to light mode after page refresh
- Improved user experience with persistent theme preference

Fixes #issue-dark-mode-persistence

# Title and Issue number 
Title: Dark and light mode bug fixed

Issue No.: #573

Close #573

## Changes Made
- Added localStorage persistence for dark/light mode theme setting
- Enhanced theme state initialization to read from localStorage on app load  
- Implemented useEffect hook for automatic saving when theme changes
- Fixed bug where theme preference was lost after page refresh/reload

### Technical Details:
- Modified `src/Context/ShopContext.jsx` to include localStorage functionality
- Added `useEffect` import for React hooks
- Enhanced theme state initialization with localStorage check
- Automatic persistence of theme changes to browser storage

## Screenshots (if applicable)
[Include any relevant screenshots or images to support your changes.]

## Checklist
I have tested these changes locally.
I have reviewed the code and ensured it follows the project's coding standards.
I have updated the documentation (if necessary).
I have read the contributing guidelines.


